### PR TITLE
Namespace RSpec DSL

### DIFF
--- a/lib/vigia/spec/api_spec.rb
+++ b/lib/vigia/spec/api_spec.rb
@@ -1,6 +1,4 @@
-# encoding: utf-8
-
-describe Vigia::Rspec do
+RSpec.describe Vigia::Rspec do
 
   described_class.include_shared_folders
   described_class.new.start_tests(self)

--- a/lib/vigia/version.rb
+++ b/lib/vigia/version.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
 
 module Vigia
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end

--- a/spec/lib/adapter_spec.rb
+++ b/spec/lib/adapter_spec.rb
@@ -20,7 +20,7 @@ describe Vigia::Adapter do
     let(:template) { -> { 'a proc' } }
 
     it 'raises an exception if not block has given' do
-      expect { described_class.setup_adapter('a') }.to raise_error
+      expect { described_class.setup_adapter }.to raise_error RuntimeError
     end
 
     it 'stores the block in the @template variable' do

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -49,7 +49,7 @@ describe Vigia::Config do
       context 'when host is nil' do
         let(:host) { nil }
         it 'raises an exception' do
-          expect{ subject.validate! }.to raise_error
+          expect{ subject.validate! }.to raise_error RuntimeError
         end
       end
       context 'when host exists' do

--- a/spec/lib/parameters_spec.rb
+++ b/spec/lib/parameters_spec.rb
@@ -28,7 +28,7 @@ describe Vigia::Parameters do
       end
 
       it 'raises an exception' do
-        expect { subject }.to raise_error
+        expect { subject }.to raise_error RuntimeError
       end
     end
 
@@ -38,7 +38,7 @@ describe Vigia::Parameters do
       end
 
       it 'raises an exception' do
-        expect { subject }.to raise_error
+        expect { subject }.to raise_error RuntimeError
       end
     end
   end

--- a/spec/lib/sail/example_spec.rb
+++ b/spec/lib/sail/example_spec.rb
@@ -144,8 +144,8 @@ describe Vigia::Sail::Example do
     context 'when expectation does not respond to :call' do
       let(:block) { 'a string' }
 
-      it 'raises an exception' do
-        expect { subject.expectation }.to raise_error
+      it 'raises a RuntimeError' do
+        expect { subject.expectation }.to raise_error RuntimeError
       end
     end
   end

--- a/spec/lib/sail/examples/default_spec.rb
+++ b/spec/lib/sail/examples/default_spec.rb
@@ -33,8 +33,9 @@ describe 'Vigia default examples' do
           allow(result).to receive(:code).and_return(300..301)
         end
 
-        it 'fails' do
-          expect { instance_exec(&subject[:expectation]) }.to raise_error
+        it 'fails with the right exception' do
+          expect { instance_exec(&subject[:expectation]) }
+            .to raise_error RSpec::Expectations::ExpectationNotMetError
         end
       end
     end
@@ -58,8 +59,9 @@ describe 'Vigia default examples' do
           allow(result).to receive(:code).and_return(201)
         end
 
-        it 'fails' do
-          expect { instance_exec(&subject[:expectation]) }.to raise_error
+        it 'fails with the right exception' do
+          expect { instance_exec(&subject[:expectation]) }
+            .to raise_error RSpec::Expectations::ExpectationNotMetError
         end
       end
     end
@@ -88,8 +90,9 @@ describe 'Vigia default examples' do
    context 'when the expected headers are not included in the result' do
       let(:result_headers) { { another: 'another content' } }
 
-      it 'fails' do
-        expect { instance_exec(&subject[:expectation]) }.to raise_error
+      it 'fails with the right exception' do
+        expect { instance_exec(&subject[:expectation]) }
+          .to raise_error RSpec::Expectations::ExpectationNotMetError
       end
     end
   end

--- a/spec/lib/vigia_spec.rb
+++ b/spec/lib/vigia_spec.rb
@@ -19,8 +19,8 @@ describe Vigia do
     context 'when config is nil' do
       let(:config) { nil }
 
-      it 'raises an exception' do
-        expect { described_class.rspec! }.to raise_error
+      it 'raises an RuntimeError' do
+        expect { described_class.rspec! }.to raise_error RuntimeError
       end
     end
 
@@ -30,7 +30,7 @@ describe Vigia do
       end
 
       it 'raises an exception' do
-        expect { described_class.rspec! }.to raise_error
+        expect { described_class.rspec! }.to raise_error RuntimeError
       end
     end
 

--- a/vigia.gemspec
+++ b/vigia.gemspec
@@ -30,8 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'sinatra'
   spec.add_development_dependency 'celluloid'
   spec.add_development_dependency 'json'
-  spec.add_development_dependency 'pry-debugger'
+  spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'cucumber'
 end
-


### PR DESCRIPTION
#### Description

When `expose_dsl_globally` RSpec config option is set to `false`, RSpec does not monkey patch the main object namespace.

Vigia was expecting to have the RSpec DSL methods (like `describe`, `context`) available by default.

This PR changes the Vigia starting point and namespace the example group definition properly.

Fixes https://github.com/nogates/vigia/issues/18