### PR TITLE
Querystring parameters with dashes create invalid URIs

### DIFF
--- a/lib/vigia/adapters/raml.rb
+++ b/lib/vigia/adapters/raml.rb
@@ -104,7 +104,14 @@ module Vigia
       def query_parameters(method)
         method.apply_traits if method.traits.any? # Does this belong here RAML?
         return '' if method.query_parameters.empty?
-        "{?#{ method.query_parameters.keys.join(',') }}"
+
+        "{?#{ query_string(method) }}"
+      end
+
+      def query_string(method)
+        method.query_parameters.keys.map do |key|
+          key.to_s.gsub('-', '%2D')
+        end.join(',')
       end
     end
   end

--- a/lib/vigia/adapters/raml.rb
+++ b/lib/vigia/adapters/raml.rb
@@ -85,7 +85,11 @@ module Vigia
 
       def format_parameters(raml_hash)
         raml_hash.values.each_with_object([]) do |parameter, array|
-          array << { name: parameter.name, value: parameter.example, required: !parameter.optional }
+          array << {
+            name:     parameter.name.gsub('-', '%2D'),
+            value:    parameter.example,
+            required: !parameter.optional
+          }
         end
       end
 

--- a/spec/lib/adapters/raml_spec.rb
+++ b/spec/lib/adapters/raml_spec.rb
@@ -37,7 +37,7 @@ describe Vigia::Adapters::Raml do
     end
   end
 
-  describe 'expected_headers' do
+  describe '#expected_headers' do
     let(:body)          { double(parent: response) }
     let(:response)      { double(headers: headers, name: response_name) }
     let(:response_name) { 200 }
@@ -60,6 +60,36 @@ describe Vigia::Adapters::Raml do
 
       it 'returns the header with a nil value' do
         expect(subject.expected_headers(body)).to eql(content_type: nil)
+      end
+    end
+  end
+
+  describe '#format_parameters' do
+    let(:method) do
+      instance_double(
+        Raml::Method,
+        parent:           resource,
+        query_parameters: parameters
+      )
+    end
+    let(:resource)          { double(uri_parameters: {}) }
+    let(:parameters)        { {} }
+
+    context 'when the method parameters include an hyphen in the name' do
+      let(:parameters)        { { 'api-key' => api_key_parameter } }
+      let(:api_key_parameter) do
+        instance_double(
+          Raml::Parameter::UriParameter,
+          name:     'api-key',
+          example:  '123',
+          optional: true
+        )
+      end
+
+      it 'formats the paramter name properly' do
+        expect(subject.parameters_for(method)).to eq [
+          { name: 'api%2Dkey', value: '123', required: false }
+        ]
       end
     end
   end

--- a/spec/lib/adapters/raml_spec.rb
+++ b/spec/lib/adapters/raml_spec.rb
@@ -91,5 +91,13 @@ describe Vigia::Adapters::Raml do
         expect(subject.resource_uri_template(method)).to eql('/posts{?page,sort}')
       end
     end
+
+    context 'when a query parameter contains an hyphen' do
+      let(:parameters) { { :"api-key" => 'The API Key' } }
+
+      it 'returns the resource template with the hyphen encoded' do
+        expect(subject.resource_uri_template(method)).to eql('/posts{?api%2Dkey}')
+      end
+    end
   end
 end

--- a/spec/lib/adapters/raml_spec.rb
+++ b/spec/lib/adapters/raml_spec.rb
@@ -75,21 +75,56 @@ describe Vigia::Adapters::Raml do
     let(:resource)          { double(uri_parameters: {}) }
     let(:parameters)        { {} }
 
-    context 'when the method parameters include an hyphen in the name' do
-      let(:parameters)        { { 'api-key' => api_key_parameter } }
+    context 'when the method parameters includes rfc 3986 chars in the name' do
+      let(:parameters)        { { "api#{ char }key" => api_key_parameter } }
       let(:api_key_parameter) do
         instance_double(
           Raml::Parameter::UriParameter,
-          name:     'api-key',
+          name:     "api#{ char }key",
           example:  '123',
           optional: true
         )
       end
 
-      it 'formats the paramter name properly' do
-        expect(subject.parameters_for(method)).to eq [
-          { name: 'api%2Dkey', value: '123', required: false }
-        ]
+
+      context 'when the char is an hyphen' do
+        let(:char) { '-' }
+
+        it 'formats the paramter name properly' do
+          expect(subject.parameters_for(method)).to eq [
+            { name: 'api%2Dkey', value: '123', required: false }
+          ]
+        end
+      end
+
+      context 'when the char is a tilde' do
+        let(:char) { '~' }
+
+        it 'formats the paramter name properly' do
+          expect(subject.parameters_for(method)).to eq [
+            { name: 'api%7Ekey', value: '123', required: false }
+          ]
+        end
+      end
+
+      context 'when the char is a dot' do
+        let(:char) { '.' }
+
+        it 'formats the paramter name properly' do
+          expect(subject.parameters_for(method)).to eq [
+            { name: 'api%2Ekey', value: '123', required: false }
+          ]
+        end
+      end
+
+      context 'when multiple' do
+        let(:char) { '.~-.' }
+
+        it 'formats the paramter name properly' do
+          expect(subject.parameters_for(method)).to eq [
+            { name: 'api%2E%7E%2D%2Ekey', value: '123', required: false }
+          ]
+        end
       end
     end
   end


### PR DESCRIPTION
It looks like querystring parameters with dashes generate invalid URIs:

Subset of raml showing failing and working:

````
baseUri: http://localhost:3000
...
/test:
  get:
    queryParameters:
      api-key:
        type: string
        example: 123-example
````

Fails generating `http://localhost:3000/test{?api-key}` and causing `bad URI(is not URI?)`

````
baseUri: http://localhost:3000
...
/test:
  get:
    queryParameters:
      api%2Dkey:
        type: string
        example: 123-example
````

Works generating `http://localhost:3000/test?api-key=123-example`

Reason it's happening is due to the URI template RFC / addressable's behavior around URL expansion which is used by the vigia gem:

````
require 'addressable/template'
Addressable::Template.new("/test{?api-key}").expand({"api-key"=>"123-example"} ).to_s
 => "/test{?api-key}"
Addressable::Template.new("/test{?api%2Dkey}").expand({"api%2Dkey"=>"123-example"} ).to_s
 => "/test?api%2Dkey=123-example"
````

It's just an oddity of the URI template reserving the hyphen for variable names while its unreserved for URIs in general. I'd think the best course of action would be to allow the RAML doc to list it with a hyphen but have the logic in the adapters perhaps encode it there since it's more of a quirk with the URI templating logic / RFC than something with RAML.