### PR TITLE
Use example field as body payload

### DIFF
--- a/lib/vigia/adapters/raml.rb
+++ b/lib/vigia/adapters/raml.rb
@@ -38,7 +38,7 @@ module Vigia
             uri_template:  -> { adapter.resource_uri_template(method) },
             parameters:    -> { adapter.parameters_for(method) },
             headers:       -> { adapter.request_headers(body) },
-            payload:       -> { adapter.payload_for(method, body) if adapter.with_payload?(method.name) }
+            payload:       -> { adapter.payload_for(method, body) }
           },
           expectations: {
              code:    -> { response.name.to_i },
@@ -74,7 +74,9 @@ module Vigia
 
       def payload_for(method, body)
         return unless with_payload?(method.name)
-        request_body_for(method, body).schema.value
+
+        payload = request_body_for(method, body)
+        payload.example || payload.schema.value
       end
 
       def with_payload?(method_name)


### PR DESCRIPTION
I have a RAML file that looks like this:

```yaml
post:
  body:
    schema: !include schema/some.schema.json
    example: |
      {...}
```

When the POST test runs, the content of the `schema/some.schema.json` file is used as the body. I was expecting the `example` data to be used instead, as documented here:

https://github.com/raml-org/raml-spec/blob/master/raml-0.8.md#example-4
> Documentation generators MUST use body properties' example attributes to generate example invocations.

https://github.com/raml-org/raml-spec/blob/raml-10/versions/raml-10/raml-10.md#type-declarations
> An example of an instance of this type. This can be used, e.g., by documentation generators to generate sample values for an object of this type.

I think the [`Vigia::Adapters::Raml#payload_for`](https://github.com/nogates/vigia/blob/master/lib/vigia/adapters/raml.rb#L75-L78) method should be changed to something like:

```ruby
def payload_for(method, body)
  return unless with_payload?(method.name)
  payload = request_body_for(method, body)
  payload.example || payload.schema.value
end
```

Thanks!