### PR TITLE
Move shared methods to adapter base class to allow delete request to have an optional payload

### DIFF
--- a/features/step_definitions/rspec.rb
+++ b/features/step_definitions/rspec.rb
@@ -21,5 +21,3 @@ end
 Then(/^the error output should be empty$/) do
   expect(@vigia_stderr).to be_empty
 end
-
-

--- a/lib/vigia/adapter.rb
+++ b/lib/vigia/adapter.rb
@@ -22,6 +22,14 @@ module Vigia
       end
     end
 
+    def with_payload?(method)
+      [ :post, :patch, :put, :delete ].include?(method.to_s.downcase.to_sym)
+    end
+
+    def required_payload?(method)
+      [ :post, :patch, :put ].include?(method.to_s.downcase.to_sym)
+    end
+
     class Structure
       class << self
         def generate(adapter, structure)

--- a/spec/lib/adapters/blueprint_spec.rb
+++ b/spec/lib/adapters/blueprint_spec.rb
@@ -184,6 +184,7 @@ HOST: http://myblog.com/
   describe '#payload_for' do
     context 'when the payload exists' do
       let(:payload_body) { 'The body' }
+
       it 'returns the payload' do
         expect(subject.payload_for(apib_example, response))
           .to eql('The body')
@@ -191,6 +192,7 @@ HOST: http://myblog.com/
     end
 
     context 'when the payload does not exist' do
+      let(:action_method) { 'POST' }
       let(:other_response) do
         instance_double(
           RedSnow::Payload,

--- a/spec/support/shared_examples/redsnow_doubles.rb
+++ b/spec/support/shared_examples/redsnow_doubles.rb
@@ -167,8 +167,8 @@ shared_examples "redsnow doubles" do
   end
 
   let(:apib_example) do
-    instance_double(
-      RedSnow::TransactionExample,
+    double(
+      action: action,
       requests: apib_requests,
       responses: apib_responses
     )


### PR DESCRIPTION
#### Description

Vigia wasn't allowing to include a payload as part of the request as was described in #22 and fixed in #23. However, this wasn't only an error in the raml adapter, but also in the blueprint adapter. This PR refactors a bit the implementation and consolidates the approach in both adapters.

cc/ @joanniclaborde
